### PR TITLE
remove tooltip

### DIFF
--- a/sveltefrontend/src/lib/components/table.svelte
+++ b/sveltefrontend/src/lib/components/table.svelte
@@ -5,9 +5,6 @@
     const colCount = $derived(singerlist.length);
 </script>
 
-<div id={`tooltip`} class="tooltip hidden absolute bg-yellow-300 text-black text-xs rounded border-2 border-yellow-600 py-1 px-2 z-50">
-    default
-</div>
 <table class="table-fixed w-full">
     <thead class="sticky top-0 bg-yellow-200 z-10">
         <tr class="h-8 sm:h-12">
@@ -25,19 +22,6 @@
                     id={`song-${i}`}
                     class="h-full px-2 sm:px-4 whitespace-nowrap overflow-hidden text-ellipsis relative"
                     title={song}
-                    onclick={(event) => {
-                        const tooltip = document.getElementById(`tooltip`);
-                        const songElement = document.getElementById(`song-${i}`);
-                        if (tooltip && songElement) {
-                            tooltip.classList.remove('hidden');
-                            tooltip.textContent = song;
-                            tooltip.style.left = `${songElement.offsetLeft + 10}px`;
-                            tooltip.style.top = `${songElement.offsetTop}px`;
-                            setTimeout(() => {
-                                tooltip.classList.add('hidden');
-                            }, 1000);
-                        }
-                    }}
                     >
                         <span class="font-bold text-xs sm:text-base text-yellow-600">
                             {i + 1}. 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced the custom tooltip on table song cells with the browser’s native tooltip shown on hover.
  * Removed click-to-toggle tooltip behavior; tooltips now display via standard hover/focus interactions and use default browser styling.
  * No changes to table data, layout, or other interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->